### PR TITLE
Download banner as jpeg

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ const App = () => {
       height: 420,
       scale: 1
     }).then(canvas => {
-      setImgURL(canvas.toDataURL('image/jpg'))
+      setImgURL(canvas.toDataURL('image/jpeg'))
     });
   }, [values])
 


### PR DESCRIPTION
The types allowed by toDataUrl are image/png and image/jpeg. Using image/jpg would make the browser fallback to image/png and result in a .jpg file that was actually a png.

That said, a png file is probably better in most cases, so we might be better off using image/png and renaming the file to banner.png